### PR TITLE
Added Spout Support

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,7 @@
 name: Vampire
 version: 3.5.4
 main: com.massivecraft.vampire.P
+softdepend: [Spout]
 commands:
   v:
     description: All of the Vampire commands

--- a/src/com/massivecraft/vampire/P.java
+++ b/src/com/massivecraft/vampire/P.java
@@ -102,6 +102,13 @@ public class P extends JavaPlugin {
 		Lang.load();
 		CommonConf.load();
 		TrueBloodConf.load();
+		SpoutConf.load();
+		
+		//Check If Spout Is Loaded... If Not Disable Spout Features (softdepend Ensures Load After Spout)
+		if(SpoutConf.EnableSpout && !this.getServer().getPluginManager().isPluginEnabled("Spout")){
+			log("Spout Not Found, Disabling All Spoutiness.");
+			SpoutConf.EnableSpout = false;
+		}
 		
 		// Do an interesting test
 		if (Conf.regenBloodPerHealth < Conf.playerBloodQuality) {
@@ -117,7 +124,8 @@ public class P extends JavaPlugin {
 		
 		// Register events
 		PluginManager pm = this.getServer().getPluginManager();
-		//pm.registerEvent(Event.Type.PLAYER_JOIN, this.playerListener, Event.Priority.Normal, this);
+		//Using PLAYER_JOIN For Spout.
+		pm.registerEvent(Event.Type.PLAYER_JOIN, this.playerListener, Event.Priority.Monitor, this);
 		pm.registerEvent(Event.Type.PLAYER_INTERACT, this.playerListener, Event.Priority.Normal, this);
 		pm.registerEvent(Event.Type.PLAYER_CHAT, this.playerListener, Event.Priority.Normal, this);
 		pm.registerEvent(Event.Type.PLAYER_ANIMATION, this.playerListener, Event.Priority.Normal, this);
@@ -199,5 +207,9 @@ public class P extends JavaPlugin {
 	
 	public static void log(Level level, String msg) {
 		Logger.getLogger("Minecraft").log(level, "["+instance.getDescription().getFullName()+"] "+msg);
+	}
+	
+	public static void callSpout(Event spoutEnable){
+		P.instance.getServer().getPluginManager().callEvent(spoutEnable);
 	}
 }

--- a/src/com/massivecraft/vampire/VSpout.java
+++ b/src/com/massivecraft/vampire/VSpout.java
@@ -1,0 +1,75 @@
+package com.massivecraft.vampire;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.getspout.spoutapi.SpoutManager;
+import org.getspout.spoutapi.player.AppearanceManager;
+//import org.getspout.spoutapi.player.SpoutPlayer;
+
+import com.massivecraft.vampire.config.SpoutConf;
+
+public class VSpout {
+	
+	public static Plugin plugin;
+	private static AppearanceManager vampApp = SpoutManager.getAppearanceManager();
+	
+	public static void makeVampire(Player player){
+		
+		if(SpoutConf.EnableSpout == false){
+			P.log("Spout Disabled");
+			return;
+		}
+		 /* //Used To Check If We Can Modify Their Gui
+		SpoutPlayer spoutPlayer = SpoutManager.getPlayer(player);
+		boolean spoutClient = spoutPlayer.isSpoutCraftEnabled();
+		*/
+		
+		//Get The Name Of The Player For Changing The Title...
+		String name = player.getName();
+		
+		//...And Add The Additional Strings That Go Above The Players Name.
+		String trueBloodTitle = SpoutConf.TrueBloodTitle+name;
+		String commonTitle = SpoutConf.CommonTitle+name;
+				
+		//Get A VPlayer Of player Just To Check If The Player Is A TrueBlood.
+		VPlayer vplayer = VPlayer.get(player);
+		
+		if(vplayer.isTrueBlood()){
+			if(SpoutConf.EnableTrueBloodSkin == true){
+				vampApp.setGlobalSkin(player, SpoutConf.TrueBloodSkinUrl);
+				P.log("Skin Set");
+			}
+			if(SpoutConf.EnableTrueBloodCape == true){
+				vampApp.setGlobalCloak(player, SpoutConf.TrueBloodCapeUrl);
+			}
+			if(SpoutConf.EnableTrueBloodTitle == true){
+				vampApp.setGlobalTitle(player, trueBloodTitle);
+			}
+		}else{
+			if(SpoutConf.EnableCommonSkin == true){
+				vampApp.setGlobalSkin(player, SpoutConf.CommonSkinUrl);
+			}
+			if(SpoutConf.EnableCommonCape == true){
+				vampApp.setGlobalCloak(player, SpoutConf.CommonCapeUrl);
+			}
+			if(SpoutConf.EnableCommonTitle == true){
+				vampApp.setGlobalTitle(player, commonTitle);
+			}
+		}
+	}
+
+	public static void unMakeVampire(Player player){
+		if(SpoutConf.EnableSpout == false){
+			return;
+		}
+		
+		/*//Same As Above But This Time To Disable
+		SpoutPlayer spoutPlayer = SpoutManager.getPlayer(player);
+		boolean spoutClient = spoutPlayer.isSpoutCraftEnabled();
+		*/
+		vampApp.resetGlobalCloak(player);	//Resets The Player's
+		vampApp.resetGlobalSkin(player);	//Skin, Title, And
+		vampApp.resetGlobalTitle(player);	//Cape.
+	}
+}
+

--- a/src/com/massivecraft/vampire/commands/VCommandCure.java
+++ b/src/com/massivecraft/vampire/commands/VCommandCure.java
@@ -29,6 +29,6 @@ public class VCommandCure extends VCommand {
 		}
 		this.sendMessage(player.getDisplayName() + " was cured from vampirism.");
 		VPlayer vplayer = VPlayer.get(player);
-		vplayer.cure();
+		vplayer.cure(player);
 	}
 }

--- a/src/com/massivecraft/vampire/commands/VCommandTurn.java
+++ b/src/com/massivecraft/vampire/commands/VCommandTurn.java
@@ -48,6 +48,6 @@ public class VCommandTurn extends VCommand {
 			this.sendMessage(player.getDisplayName() + " was turned into a vampire.");
 		}
 		
-		vplayer.turn();
+		vplayer.turn(player);
 	}
 }

--- a/src/com/massivecraft/vampire/config/SpoutConf.java
+++ b/src/com/massivecraft/vampire/config/SpoutConf.java
@@ -1,0 +1,55 @@
+package com.massivecraft.vampire.config;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.massivecraft.vampire.P;
+import com.massivecraft.vampire.util.DiscUtil;
+
+public class SpoutConf {
+	public static transient File file = new File(P.instance.getDataFolder(), "SpoutConf.json");
+	
+	public static boolean EnableSpout = false;
+	public static boolean EnableTrueBloodSkin = true;
+	public static boolean EnableTrueBloodCape = true;
+	public static boolean EnableTrueBloodTitle = true;
+	public static boolean EnableCommonSkin = true;
+	public static boolean EnableCommonCape = false;
+	public static boolean EnableCommonTitle = true;
+	public static String TrueBloodSkinUrl = "https://dl.dropbox.com/s/m5tbslhm82k1sny/skin.png";
+	public static String TrueBloodCapeUrl = "https://dl.dropbox.com/s/f5ybmjk2tn91iwa/cape.png";
+	public static String TrueBloodTitle = "TrueBlood\n";
+	public static String CommonSkinUrl = "https://dl.dropbox.com/s/m5tbslhm82k1sny/skin.png";
+	public static String CommonCapeUrl = "https://dl.dropbox.com/s/f5ybmjk2tn91iwa/cape.png";
+	public static String CommonTitle = "Common\n";
+
+	public static boolean save() {
+		P.log("Saving config to disk.");
+		try {
+			DiscUtil.write(file, P.instance.gson.toJson(new SpoutConf()));
+		} catch (IOException e) {
+			e.printStackTrace();
+			P.log("Failed to save SpoutConf to disk.");
+			return false;
+		}
+		return true;
+	}
+	
+	public static boolean load() {
+		if ( ! file.exists()) {
+			P.log("No SpoutConf to load from disk. Creating new file.");
+			save();
+			return true;
+		}
+		
+		try {
+			P.instance.gson.fromJson(DiscUtil.read(file), SpoutConf.class);
+		} catch (IOException e) {
+			e.printStackTrace();
+			P.log("Failed to load the SpoutConf from disk.");
+			return false;
+		}
+		
+		return true;
+	}
+}

--- a/src/com/massivecraft/vampire/listeners/VampireEntityListener.java
+++ b/src/com/massivecraft/vampire/listeners/VampireEntityListener.java
@@ -16,6 +16,7 @@ import com.massivecraft.vampire.util.EntityUtil;
 
 //import com.bukkit.mcteam.vampire.Vampire;
 
+@SuppressWarnings("deprecation")
 public class VampireEntityListener extends EntityListener {
 	
 	/**

--- a/src/com/massivecraft/vampire/listeners/VampireEntityListenerMonitor.java
+++ b/src/com/massivecraft/vampire/listeners/VampireEntityListenerMonitor.java
@@ -16,6 +16,7 @@ import com.massivecraft.vampire.config.*;
 import com.massivecraft.vampire.util.EntityUtil;
 
 
+@SuppressWarnings("deprecation")
 public class VampireEntityListenerMonitor extends EntityListener {
 	
 	/**

--- a/src/com/massivecraft/vampire/listeners/VampirePlayerListener.java
+++ b/src/com/massivecraft/vampire/listeners/VampirePlayerListener.java
@@ -5,15 +5,18 @@ import java.util.List;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.CreatureType;
+import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerAnimationEvent;
 import org.bukkit.event.player.PlayerAnimationType;
 import org.bukkit.event.player.PlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerListener;
 
-import com.massivecraft.vampire.VPlayer;
 import com.massivecraft.vampire.P;
+import com.massivecraft.vampire.VPlayer;
+import com.massivecraft.vampire.VSpout;
 import com.massivecraft.vampire.config.Conf;
 import com.massivecraft.vampire.config.Lang;
 import com.massivecraft.vampire.util.TextUtil;
@@ -28,7 +31,7 @@ public class VampirePlayerListener extends PlayerListener {
 		if ( ! (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK) ) {
 			return;
 		}
-		
+		Player player = event.getPlayer();
 		VPlayer vplayer = VPlayer.get(event.getPlayer());
 		Material itemMaterial = event.getMaterial();
 		
@@ -65,7 +68,7 @@ public class VampirePlayerListener extends PlayerListener {
 		if (blockMaterial == Conf.altarInfectMaterial) {
 			vplayer.useAltarInfect(event.getClickedBlock());
 		} else if (blockMaterial == Conf.altarCureMaterial) {
-			vplayer.useAltarCure(event.getClickedBlock());
+			vplayer.useAltarCure(event.getClickedBlock(), player);
 		}
 	}
 	
@@ -108,6 +111,12 @@ public class VampirePlayerListener extends PlayerListener {
 			vplayer.jump(Conf.jumpDeltaSpeed, true);
 		}
 	}
-	
-	
+	public void onPlayerJoin(PlayerJoinEvent event){
+		Player player = event.getPlayer();
+		VPlayer vPlayer = VPlayer.get(player);
+		if(vPlayer.isVampire()){
+			VSpout.makeVampire(player);
+		}
+	}
 }
+


### PR DESCRIPTION
Added Spout features. Added the option to change player skin for trueblood/common, add a cape to trueblood/common and change the title above players head for trueblood/common. Each feature can be enabled or disabled for trueblood and/or common. Added softdepend to plugin.yml to make sure spout loads first to check if it is enabled. If not then the spout features are automatically disabled with a log message.
